### PR TITLE
Add ssh agent key forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,8 @@ Vagrant.configure(2) do |config|
 
   config.vm.box = "ubuntu/trusty64"
   config.vm.define "pyspark-box"
+  # Forward ssh keys from host to guest
+  config.ssh.forward_agent = true
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048


### PR DESCRIPTION
Add the [ssh agent key forwarding](https://developer.github.com/guides/using-ssh-agent-forwarding/) config to `Vagrantfile` so that the ssh keys added to the laptop's SSH agent are forwarding by the `vagrant ssh` command.

```
# Start ssh-agent.  NOT necessary on a Mac which has one started by default
ssh-agent

# Add ssh key to ssh-agent on a Mac
ssh-add

# Use vagrant ssh.  The guest will behave as if it has a local ssh private key,
# which will allow one to use Github with ssh without having to manually add
# the ssh private key to the guest.
vagrant ssh
```